### PR TITLE
Remove log info from mouse enter/leave event.

### DIFF
--- a/src/js/extensions/AutoScroll/AutoScroll.ts
+++ b/src/js/extensions/AutoScroll/AutoScroll.ts
@@ -137,7 +137,6 @@ export function AutoScroll( Splide: Splide, Components: Components, options: Opt
       bind( root, 'mouseenter mouseleave', e => {
         hovered = e.type === 'mouseenter';
         autoToggle();
-        console.log( 'enter' );
       } );
     }
 


### PR DESCRIPTION
## Description

There is a console log "enter" when event mouse enter/leave occur.
![image](https://user-images.githubusercontent.com/14315700/147106979-1cfa2861-06d9-4221-8c91-2a8968d738a4.png)

This PR removes it as it should be shown only during development or on some develop version.
